### PR TITLE
Simplify array building in Print-LinkedList function

### DIFF
--- a/ProblemOfTheDay/2025-09-08_MergeSortLinkedList/merge_sort_linked_list.ps1
+++ b/ProblemOfTheDay/2025-09-08_MergeSortLinkedList/merge_sort_linked_list.ps1
@@ -62,9 +62,9 @@ function Build-LinkedList($arr) {
 # Print linked list
 function Print-LinkedList($head) {
     $curr = $head
-    $out = [System.Collections.ArrayList]::new()
+    $out = @()
     while ($curr) {
-        [void]$out.Add($curr.data)
+        $out += $curr.data
         $curr = $curr.next
     }
     Write-Output ($out -join ' -> ')

--- a/ProblemOfTheDay/2025-09-09_AssignMiceHoles/README.md
+++ b/ProblemOfTheDay/2025-09-09_AssignMiceHoles/README.md
@@ -1,0 +1,25 @@
+# Assign Mice Holes - Solution Explanation
+
+## Problem Recap
+Given two arrays of equal length, `mices[]` and `holes[]`, representing positions on a line, assign each mouse to a unique hole so that the maximum time taken by any mouse to reach its assigned hole is minimized. Each move (left/right) takes 1 minute.
+
+## Approach
+- **Sort** both arrays.
+- Pair the ith mouse with the ith hole.
+- The answer is the **maximum absolute difference** between the paired positions.
+
+This greedy approach works because sorting ensures that the largest gaps are minimized when pairing closest available positions.
+
+## Example
+- Input: `mices = [4, -4, 2]`, `holes = [4, 0, 5]`
+- Sorted: `mices = [-4, 2, 4]`, `holes = [0, 4, 5]`
+- Pairings: (-4,0), (2,4), (4,5)
+- Times: 4, 2, 1
+- Maximum: **4**
+
+## How to Run
+1. Open PowerShell.
+2. Navigate to the script directory.
+3. Run: `./assign_mice_holes.ps1`
+
+The script will print results for the provided test cases.

--- a/ProblemOfTheDay/2025-09-09_AssignMiceHoles/assign_mice_holes.ps1
+++ b/ProblemOfTheDay/2025-09-09_AssignMiceHoles/assign_mice_holes.ps1
@@ -1,0 +1,44 @@
+# Assign Mice Holes - GeeksforGeeks Problem of the Day (2025-09-09)
+#
+# Problem:
+# Given two arrays mices[] and holes[] of the same size, representing positions on a line.
+# Each hole can accommodate one mouse. Each move (left/right) takes 1 minute.
+# Assign each mouse to a hole to minimize the time taken by the last mouse to reach its hole.
+#
+# Approach:
+# Sort both arrays and pair the ith mouse with the ith hole.
+# The answer is the maximum absolute difference between paired positions.
+
+function Get-MinimumTimeToAssignMiceHoles {
+    param (
+        [int[]]$mices,
+        [int[]]$holes
+    )
+    # Sort both arrays
+    $mices = $mices | Sort-Object
+    $holes = $holes | Sort-Object
+
+    $maxTime = 0
+    for ($i = 0; $i -lt $mices.Length; $i++) {
+        $time = [math]::Abs($mices[$i] - $holes[$i])
+        if ($time -gt $maxTime) {
+            $maxTime = $time
+        }
+    }
+    return $maxTime
+}
+
+# Test cases
+Write-Host "Test 1"
+$mices1 = 4, -4, 2
+$holes1 = 4, 0, 5
+$result1 = Get-MinimumTimeToAssignMiceHoles -mices $mices1 -holes $holes1
+Write-Host "Input: mices = $($mices1 -join ', '), holes = $($holes1 -join ', ')"
+Write-Host "Output: $result1"  # Expected: 4
+
+Write-Host "`nTest 2"
+$mices2 = 1, 2
+$holes2 = 20, 10
+$result2 = Get-MinimumTimeToAssignMiceHoles -mices $mices2 -holes $holes2
+Write-Host "Input: mices = $($mices2 -join ', '), holes = $($holes2 -join ', ')"
+Write-Host "Output: $result2"  # Expected: 18


### PR DESCRIPTION
Replace ArrayList with simple array concatenation for better readability and reduced complexity in the linked list printing utility.