### PR TITLE
feat: add Longest Span in Two Binary Arrays problem

### DIFF
--- a/ProblemOfTheDay/2026-02-24_LongestSpanTwoBinaryArrays/README.md
+++ b/ProblemOfTheDay/2026-02-24_LongestSpanTwoBinaryArrays/README.md
@@ -1,0 +1,79 @@
+# Longest Span in Two Binary Arrays
+
+**GeeksforGeeks Problem of the Day - February 24, 2026**
+
+## Problem Description
+
+Given two binary arrays, `a1[]` and `a2[]` of equal length, find the length of the longest common span `(i, j)`, where `i <= j` such that:
+
+```
+a1[i] + a1[i+1] + ... + a1[j] = a2[i] + a2[i+1] + ... + a2[j]
+```
+
+In other words, find the longest subarray where both arrays have the same sum.
+
+## Examples
+
+### Example 1:
+```
+Input:  a1[] = [0, 1, 0, 0, 0, 0], a2[] = [1, 0, 1, 0, 0, 1]
+Output: 4
+Explanation: The longest span with same sum is from index 1 to 4 (0-indexed).
+  a1[1..4] = [1, 0, 0, 0] → sum = 1
+  a2[1..4] = [0, 1, 0, 0] → sum = 1
+```
+
+### Example 2:
+```
+Input:  a1[] = [0, 1, 0, 1, 1, 1, 1], a2[] = [1, 1, 1, 1, 1, 0, 1]
+Output: 6
+Explanation: The longest span with same sum is from index 1 to 6.
+```
+
+### Example 3:
+```
+Input:  a1[] = [0, 0, 0], a2[] = [1, 1, 1]
+Output: 0
+Explanation: No span exists where sums are equal.
+```
+
+## Approach
+
+### Key Insight: Difference Array + Prefix Sum
+
+1. **Transform the problem**: Instead of comparing sums directly, create a difference array:
+   ```
+   diff[i] = a1[i] - a2[i]
+   ```
+
+2. **Observation**: If `sum(a1[i..j]) = sum(a2[i..j])`, then:
+   ```
+   sum(diff[i..j]) = sum(a1[i..j]) - sum(a2[i..j]) = 0
+   ```
+
+3. **Problem becomes**: Find the longest subarray with sum = 0
+
+4. **Solution using Prefix Sum + HashMap**:
+   - Calculate prefix sums of the difference array
+   - If `prefixSum[j] == prefixSum[i-1]`, then `sum(diff[i..j]) = 0`
+   - Use a hash map to store the first occurrence of each prefix sum
+   - When we see the same prefix sum again, the subarray between them has sum = 0
+
+### Algorithm:
+
+1. Create difference array: `diff[i] = a1[i] - a2[i]`
+2. Initialize: `prefixSum = 0`, `hashMap = {0: -1}` (handles case when subarray starts at index 0)
+3. For each index `i`:
+   - Add `diff[i]` to `prefixSum`
+   - If `prefixSum` exists in hashMap:
+     - Update `maxLength = max(maxLength, i - hashMap[prefixSum])`
+   - Else:
+     - Store `hashMap[prefixSum] = i`
+4. Return `maxLength`
+
+### Time Complexity: O(n)
+### Space Complexity: O(n)
+
+## Problem Link
+
+[GeeksforGeeks - Longest Span in Two Binary Arrays](https://www.geeksforgeeks.org/problems/longest-span-with-same-sum-in-two-binary-arrays5142/1)

--- a/ProblemOfTheDay/2026-02-24_LongestSpanTwoBinaryArrays/longest_span_two_binary_arrays.ps1
+++ b/ProblemOfTheDay/2026-02-24_LongestSpanTwoBinaryArrays/longest_span_two_binary_arrays.ps1
@@ -1,0 +1,209 @@
+<#
+.SYNOPSIS
+    Finds the longest span (subarray) with the same sum in two binary arrays.
+
+.DESCRIPTION
+    Given two binary arrays a1[] and a2[] of equal length, this function finds
+    the length of the longest common span (i, j) where i <= j such that:
+    sum(a1[i..j]) = sum(a2[i..j])
+
+.PARAMETER a1
+    First binary array (containing only 0s and 1s)
+
+.PARAMETER a2
+    Second binary array (containing only 0s and 1s)
+
+.OUTPUTS
+    Integer representing the length of the longest span with equal sum
+
+.EXAMPLE
+    Get-LongestSpan -a1 @(0,1,0,0,0,0) -a2 @(1,0,1,0,0,1)
+    Returns: 4
+
+.NOTES
+    Algorithm: Difference Array + Prefix Sum + HashMap
+    Time Complexity: O(n)
+    Space Complexity: O(n)
+
+    Key Insight:
+    - If sum(a1[i..j]) = sum(a2[i..j]), then sum(diff[i..j]) = 0
+      where diff[k] = a1[k] - a2[k]
+    - Problem reduces to finding longest subarray with sum = 0
+    - Use prefix sums: if prefixSum[j] == prefixSum[i-1], then sum(diff[i..j]) = 0
+#>
+
+function Get-LongestSpan {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $false)]
+        [int[]]$a1 = @(),
+
+        [Parameter(Mandatory = $false)]
+        [int[]]$a2 = @()
+    )
+
+    # Handle empty arrays
+    if ($null -eq $a1 -or $a1.Length -eq 0) {
+        return 0
+    }
+    if ($null -eq $a2 -or $a2.Length -eq 0) {
+        return 0
+    }
+
+    # Validate inputs
+    if ($a1.Length -ne $a2.Length) {
+        throw "Arrays must have equal length"
+    }
+
+    $n = $a1.Length
+
+    # HashMap to store first occurrence of each prefix sum
+    # Key: prefix sum value, Value: first index where this sum was seen
+    # Initialize with {0: -1} to handle subarrays starting from index 0
+    $prefixSumMap = @{}
+    $prefixSumMap[0] = -1
+
+    $prefixSum = 0
+    $maxLength = 0
+
+    for ($i = 0; $i -lt $n; $i++) {
+        # Calculate difference and add to prefix sum
+        # diff[i] = a1[i] - a2[i]
+        $diff = $a1[$i] - $a2[$i]
+        $prefixSum += $diff
+
+        if ($prefixSumMap.ContainsKey($prefixSum)) {
+            # We've seen this prefix sum before!
+            # The subarray from (firstOccurrence + 1) to current index has sum = 0
+            $length = $i - $prefixSumMap[$prefixSum]
+            if ($length -gt $maxLength) {
+                $maxLength = $length
+            }
+        }
+        else {
+            # First time seeing this prefix sum, store the index
+            $prefixSumMap[$prefixSum] = $i
+        }
+    }
+
+    return $maxLength
+}
+
+# ===============================================
+# EXPLANATION OF THE ALGORITHM
+# ===============================================
+<#
+Let's trace through Example 1:
+a1 = [0, 1, 0, 0, 0, 0]
+a2 = [1, 0, 1, 0, 0, 1]
+
+Step 1: Create difference array (conceptually)
+diff = [0-1, 1-0, 0-1, 0-0, 0-0, 0-1]
+     = [-1,  1,  -1,   0,   0,  -1]
+
+Step 2: Calculate prefix sums and track in HashMap
+
+Index | a1[i] | a2[i] | diff | prefixSum | Action                    | maxLength
+------|-------|-------|------|-----------|---------------------------|----------
+init  |       |       |      | 0         | Store {0: -1}             | 0
+  0   |   0   |   1   |  -1  | -1        | Store {-1: 0}             | 0
+  1   |   1   |   0   |   1  | 0         | Found 0 at -1! len=1-(-1)=2| 2
+  2   |   0   |   1   |  -1  | -1        | Found -1 at 0! len=2-0=2  | 2
+  3   |   0   |   0   |   0  | -1        | Found -1 at 0! len=3-0=3  | 3
+  4   |   0   |   0   |   0  | -1        | Found -1 at 0! len=4-0=4  | 4
+  5   |   0   |   1   |  -1  | -2        | Store {-2: 5}             | 4
+
+Result: 4 (subarray from index 1 to 4)
+
+Why does this work?
+- prefixSum[j] - prefixSum[i-1] = sum(diff[i..j])
+- If prefixSum[j] == prefixSum[i-1], then sum(diff[i..j]) = 0
+- sum(diff[i..j]) = 0 means sum(a1[i..j]) = sum(a2[i..j])
+#>
+
+# ===============================================
+# ALTERNATIVE BRUTE FORCE SOLUTION (for verification)
+# ===============================================
+function Get-LongestSpanBruteForce {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)]
+        [int[]]$a1,
+
+        [Parameter(Mandatory = $true)]
+        [int[]]$a2
+    )
+
+    $n = $a1.Length
+    $maxLength = 0
+
+    # Try all possible subarrays
+    for ($i = 0; $i -lt $n; $i++) {
+        $sum1 = 0
+        $sum2 = 0
+        for ($j = $i; $j -lt $n; $j++) {
+            $sum1 += $a1[$j]
+            $sum2 += $a2[$j]
+
+            if ($sum1 -eq $sum2) {
+                $length = $j - $i + 1
+                if ($length -gt $maxLength) {
+                    $maxLength = $length
+                }
+            }
+        }
+    }
+
+    return $maxLength
+}
+
+# ===============================================
+# DEMO / MAIN EXECUTION
+# ===============================================
+if ($MyInvocation.InvocationName -ne '.') {
+    Write-Host "=" * 60 -ForegroundColor Cyan
+    Write-Host "Longest Span in Two Binary Arrays" -ForegroundColor Cyan
+    Write-Host "=" * 60 -ForegroundColor Cyan
+
+    # Example 1
+    $a1 = @(0, 1, 0, 0, 0, 0)
+    $a2 = @(1, 0, 1, 0, 0, 1)
+    Write-Host "`nExample 1:" -ForegroundColor Yellow
+    Write-Host "  a1 = [$($a1 -join ', ')]"
+    Write-Host "  a2 = [$($a2 -join ', ')]"
+    $result = Get-LongestSpan -a1 $a1 -a2 $a2
+    Write-Host "  Longest span with equal sum: $result" -ForegroundColor Green
+    Write-Host "  Expected: 4"
+
+    # Example 2
+    $a1 = @(0, 1, 0, 1, 1, 1, 1)
+    $a2 = @(1, 1, 1, 1, 1, 0, 1)
+    Write-Host "`nExample 2:" -ForegroundColor Yellow
+    Write-Host "  a1 = [$($a1 -join ', ')]"
+    Write-Host "  a2 = [$($a2 -join ', ')]"
+    $result = Get-LongestSpan -a1 $a1 -a2 $a2
+    Write-Host "  Longest span with equal sum: $result" -ForegroundColor Green
+    Write-Host "  Expected: 6"
+
+    # Example 3 - No common span
+    $a1 = @(0, 0, 0)
+    $a2 = @(1, 1, 1)
+    Write-Host "`nExample 3 (no common span):" -ForegroundColor Yellow
+    Write-Host "  a1 = [$($a1 -join ', ')]"
+    Write-Host "  a2 = [$($a2 -join ', ')]"
+    $result = Get-LongestSpan -a1 $a1 -a2 $a2
+    Write-Host "  Longest span with equal sum: $result" -ForegroundColor Green
+    Write-Host "  Expected: 0"
+
+    # Example 4 - Identical arrays
+    $a1 = @(1, 0, 1, 1, 0)
+    $a2 = @(1, 0, 1, 1, 0)
+    Write-Host "`nExample 4 (identical arrays):" -ForegroundColor Yellow
+    Write-Host "  a1 = [$($a1 -join ', ')]"
+    Write-Host "  a2 = [$($a2 -join ', ')]"
+    $result = Get-LongestSpan -a1 $a1 -a2 $a2
+    Write-Host "  Longest span with equal sum: $result" -ForegroundColor Green
+    Write-Host "  Expected: 5 (entire array)"
+
+    Write-Host "`n" + ("=" * 60) -ForegroundColor Cyan
+}

--- a/ProblemOfTheDay/2026-02-24_LongestSpanTwoBinaryArrays/test_longest_span.ps1
+++ b/ProblemOfTheDay/2026-02-24_LongestSpanTwoBinaryArrays/test_longest_span.ps1
@@ -1,0 +1,210 @@
+<#
+.SYNOPSIS
+    Test suite for Longest Span in Two Binary Arrays solution
+
+.DESCRIPTION
+    Comprehensive tests including example cases, edge cases, and randomized tests
+    comparing the optimized solution against the brute force implementation.
+#>
+
+# Import the solution
+. "$PSScriptRoot\longest_span_two_binary_arrays.ps1"
+
+$script:TestsPassed = 0
+$script:TestsFailed = 0
+
+function Test-Case {
+    param (
+        [string]$Name,
+        [int[]]$a1,
+        [int[]]$a2,
+        [int]$Expected
+    )
+
+    $result = Get-LongestSpan -a1 $a1 -a2 $a2
+
+    if ($result -eq $Expected) {
+        Write-Host "[PASS] $Name" -ForegroundColor Green
+        $script:TestsPassed++
+    }
+    else {
+        Write-Host "[FAIL] $Name" -ForegroundColor Red
+        Write-Host "       a1       = [$($a1 -join ', ')]"
+        Write-Host "       a2       = [$($a2 -join ', ')]"
+        Write-Host "       Expected = $Expected"
+        Write-Host "       Got      = $result"
+        $script:TestsFailed++
+    }
+}
+
+function Test-AgainstBruteForce {
+    param (
+        [string]$Name,
+        [int[]]$a1,
+        [int[]]$a2
+    )
+
+    $optimized = Get-LongestSpan -a1 $a1 -a2 $a2
+    $bruteForce = Get-LongestSpanBruteForce -a1 $a1 -a2 $a2
+
+    if ($optimized -eq $bruteForce) {
+        Write-Host "[PASS] $Name (optimized=$optimized, brute=$bruteForce)" -ForegroundColor Green
+        $script:TestsPassed++
+    }
+    else {
+        Write-Host "[FAIL] $Name" -ForegroundColor Red
+        Write-Host "       a1         = [$($a1 -join ', ')]"
+        Write-Host "       a2         = [$($a2 -join ', ')]"
+        Write-Host "       Optimized  = $optimized"
+        Write-Host "       BruteForce = $bruteForce"
+        $script:TestsFailed++
+    }
+}
+
+Write-Host "=" * 60 -ForegroundColor Cyan
+Write-Host "Testing: Longest Span in Two Binary Arrays" -ForegroundColor Cyan
+Write-Host "=" * 60 -ForegroundColor Cyan
+Write-Host ""
+
+# ===============================================
+# EXAMPLE TEST CASES
+# ===============================================
+Write-Host "--- Example Test Cases ---" -ForegroundColor Yellow
+
+Test-Case -Name "Example 1: Basic case" `
+    -a1 @(0, 1, 0, 0, 0, 0) `
+    -a2 @(1, 0, 1, 0, 0, 1) `
+    -Expected 4
+
+Test-Case -Name "Example 2: Longer span" `
+    -a1 @(0, 1, 0, 1, 1, 1, 1) `
+    -a2 @(1, 1, 1, 1, 1, 0, 1) `
+    -Expected 6
+
+Test-Case -Name "Example 3: No common span" `
+    -a1 @(0, 0, 0) `
+    -a2 @(1, 1, 1) `
+    -Expected 0
+
+# ===============================================
+# EDGE CASES
+# ===============================================
+Write-Host ""
+Write-Host "--- Edge Cases ---" -ForegroundColor Yellow
+
+Test-Case -Name "Single element - equal" `
+    -a1 @(1) `
+    -a2 @(1) `
+    -Expected 1
+
+Test-Case -Name "Single element - unequal" `
+    -a1 @(0) `
+    -a2 @(1) `
+    -Expected 0
+
+Test-Case -Name "Empty arrays" `
+    -a1 @() `
+    -a2 @() `
+    -Expected 0
+
+Test-Case -Name "Two elements - equal" `
+    -a1 @(0, 1) `
+    -a2 @(0, 1) `
+    -Expected 2
+
+Test-Case -Name "Two elements - swap gives same sum" `
+    -a1 @(0, 1) `
+    -a2 @(1, 0) `
+    -Expected 2
+
+Test-Case -Name "Identical arrays" `
+    -a1 @(1, 0, 1, 1, 0) `
+    -a2 @(1, 0, 1, 1, 0) `
+    -Expected 5
+
+Test-Case -Name "All zeros" `
+    -a1 @(0, 0, 0, 0, 0) `
+    -a2 @(0, 0, 0, 0, 0) `
+    -Expected 5
+
+Test-Case -Name "All ones" `
+    -a1 @(1, 1, 1, 1) `
+    -a2 @(1, 1, 1, 1) `
+    -Expected 4
+
+# ===============================================
+# SPECIAL CASES
+# ===============================================
+Write-Host ""
+Write-Host "--- Special Cases ---" -ForegroundColor Yellow
+
+Test-Case -Name "Span at beginning" `
+    -a1 @(1, 0, 0, 0, 1) `
+    -a2 @(1, 0, 1, 1, 1) `
+    -Expected 2
+
+Test-Case -Name "Span at end" `
+    -a1 @(1, 1, 0, 0, 1) `
+    -a2 @(0, 0, 0, 0, 1) `
+    -Expected 3
+
+Test-Case -Name "Multiple spans - longest in middle" `
+    -a1 @(0, 1, 0, 1, 0, 1, 0) `
+    -a2 @(1, 0, 1, 0, 1, 0, 1) `
+    -Expected 6
+
+Test-Case -Name "Alternating pattern" `
+    -a1 @(0, 1, 0, 1, 0, 1) `
+    -a2 @(1, 0, 1, 0, 1, 0) `
+    -Expected 6
+
+# ===============================================
+# VERIFICATION AGAINST BRUTE FORCE
+# ===============================================
+Write-Host ""
+Write-Host "--- Verification Against Brute Force ---" -ForegroundColor Yellow
+
+# Fixed test cases
+Test-AgainstBruteForce -Name "Verify Example 1" `
+    -a1 @(0, 1, 0, 0, 0, 0) `
+    -a2 @(1, 0, 1, 0, 0, 1)
+
+Test-AgainstBruteForce -Name "Verify Example 2" `
+    -a1 @(0, 1, 0, 1, 1, 1, 1) `
+    -a2 @(1, 1, 1, 1, 1, 0, 1)
+
+# Random test cases
+Write-Host ""
+Write-Host "--- Random Test Cases ---" -ForegroundColor Yellow
+
+for ($t = 1; $t -le 10; $t++) {
+    $size = Get-Random -Minimum 5 -Maximum 20
+    $a1 = @()
+    $a2 = @()
+    for ($i = 0; $i -lt $size; $i++) {
+        $a1 += Get-Random -Minimum 0 -Maximum 2
+        $a2 += Get-Random -Minimum 0 -Maximum 2
+    }
+
+    Test-AgainstBruteForce -Name "Random test $t (size=$size)" -a1 $a1 -a2 $a2
+}
+
+# ===============================================
+# SUMMARY
+# ===============================================
+Write-Host ""
+Write-Host "=" * 60 -ForegroundColor Cyan
+Write-Host "Test Summary" -ForegroundColor Cyan
+Write-Host "=" * 60 -ForegroundColor Cyan
+Write-Host "Passed: $script:TestsPassed" -ForegroundColor Green
+Write-Host "Failed: $script:TestsFailed" -ForegroundColor $(if ($script:TestsFailed -gt 0) { "Red" } else { "Green" })
+Write-Host ""
+
+if ($script:TestsFailed -eq 0) {
+    Write-Host "All tests passed!" -ForegroundColor Green
+    exit 0
+}
+else {
+    Write-Host "Some tests failed." -ForegroundColor Red
+    exit 1
+}

--- a/problem_today.json
+++ b/problem_today.json
@@ -1,28 +1,26 @@
 ﻿{
-    "id":  1943,
-    "date":  "2026-02-20 00:00:00",
+    "id":  1947,
+    "date":  "2026-02-24 00:00:00",
     "is_solved":  false,
-    "problem_id":  702886,
-    "problem_name":  "Form the Largest Number",
-    "problem_url":  "https://www.geeksforgeeks.org/problems/largest-number-formed-from-an-array1117/1",
+    "problem_id":  702727,
+    "problem_name":  "Longest Span in two Binary Arrays",
+    "problem_url":  "https://www.geeksforgeeks.org/problems/longest-span-with-same-sum-in-two-binary-arrays5142/1",
     "difficulty":  "Medium",
     "tags":  {
                  "company_tags":  [
-                                      "Paytm",
-                                      "Zoho",
-                                      "Amazon",
-                                      "Microsoft",
-                                      "MakeMyTrip"
+
                                   ],
                  "topic_tags":  [
+                                    "prefix-sum",
+                                    "sliding-window",
                                     "Arrays",
                                     "Data Structures",
-                                    "Sorting"
+                                    "Algorithms"
                                 ]
              },
-    "remaining_time":  22801,
-    "end_date":  "2026-02-20 23:59:59",
-    "accuracy":  37.82,
-    "total_submissions":  197280,
+    "remaining_time":  21734,
+    "end_date":  "2026-02-24 23:59:59",
+    "accuracy":  48.22,
+    "total_submissions":  33784,
     "is_time_machine_reward_active":  true
 }


### PR DESCRIPTION
This pull request introduces a new "Problem of the Day" solution for "Longest Span in Two Binary Arrays" (GeeksforGeeks, Feb 24, 2026). It includes a detailed problem description, an efficient PowerShell implementation with both optimized and brute-force solutions, and a comprehensive test suite. The metadata for the current problem has also been updated.

**Problem solution and documentation:**

* Added a detailed problem description and approach in `README.md` for "Longest Span in Two Binary Arrays".
* Implemented the efficient solution and a brute-force alternative in `longest_span_two_binary_arrays.ps1`, including input validation, algorithm explanation, and demo execution with sample cases.

**Testing:**

* Added a robust test suite in `test_longest_span.ps1`, covering example, edge, special, and randomized test cases, and verifying correctness against the brute-force solution.

**Metadata update:**

* Updated `problem_today.json` to reflect the new problem, including its ID, name, URL, tags, and statistics.Add solution for GeeksforGeeks Problem of the Day (Feb 24, 2026). Uses difference array with prefix sum and hash map approach. Time complexity O(n), space complexity O(n).