### PR TITLE
feat: add Largest Number in One Swap problem solution

### DIFF
--- a/ProblemOfTheDay/2026-03-09_LargestNumberInOneSwap/README.md
+++ b/ProblemOfTheDay/2026-03-09_LargestNumberInOneSwap/README.md
@@ -1,0 +1,67 @@
+# Largest Number in One Swap
+
+## Problem Description
+
+Given a string `s`, return the **lexicographically largest** string that can be obtained by swapping at most **one pair** of characters in `s`.
+
+## Examples
+
+### Example 1
+```
+Input: s = "768"
+Output: "867"
+Explanation: Swapping the 1st and 3rd characters (7 and 8 respectively), gives the lexicographically largest string.
+```
+
+### Example 2
+```
+Input: s = "333"
+Output: "333"
+Explanation: Performing any swaps gives the same result i.e "333".
+```
+
+## Constraints
+
+- `1 ≤ |s| ≤ 10^5`
+- `'0' ≤ s[i] ≤ '9'`
+
+## Approach
+
+To get the lexicographically largest string with at most one swap:
+
+1. **Goal**: We want the largest digit as far left as possible
+2. **Strategy**: 
+   - Traverse the string from left to right
+   - For each position `i`, check if there's a larger digit to its right
+   - If found, swap with the **rightmost occurrence** of the largest digit (to maximize the result)
+   - After one swap, return the result
+
+### Algorithm
+
+1. For each position `i` from left to right:
+   - Find the maximum digit in the substring `s[i+1...n-1]`
+   - If this maximum digit is greater than `s[i]`:
+     - Find the rightmost occurrence of this maximum digit
+     - Swap `s[i]` with this rightmost maximum digit
+     - Return the result
+2. If no swap improves the string, return the original string
+
+### Why rightmost occurrence?
+
+Consider `s = "1993"`:
+- At position 0, digit is '1', max in rest is '9'
+- We have '9' at positions 1 and 2
+- Swapping with rightmost '9' (position 2) gives "9913"
+- Swapping with leftmost '9' (position 1) gives "9193"
+- "9913" > "9193", so rightmost is better
+
+### Time Complexity
+- O(n) where n is the length of the string
+
+### Space Complexity
+- O(n) for storing the character array
+
+## Solution Files
+
+- `largest_number_one_swap.ps1` - PowerShell solution implementation
+- `test_largest_number_one_swap.ps1` - Test cases to verify the solution

--- a/ProblemOfTheDay/2026-03-09_LargestNumberInOneSwap/largest_number_one_swap.ps1
+++ b/ProblemOfTheDay/2026-03-09_LargestNumberInOneSwap/largest_number_one_swap.ps1
@@ -1,0 +1,179 @@
+<#
+.SYNOPSIS
+    Largest Number in One Swap - GeeksforGeeks Problem of the Day (2026-03-09)
+
+.DESCRIPTION
+    Given a string s (representing a number), return the lexicographically largest 
+    string that can be obtained by swapping at most one pair of characters in s.
+
+.PARAMETER s
+    A string containing digits '0' to '9'
+
+.EXAMPLE
+    Get-LargestNumberInOneSwap -s "768"
+    Returns: "867"
+
+.EXAMPLE
+    Get-LargestNumberInOneSwap -s "333"
+    Returns: "333"
+
+.NOTES
+    Algorithm:
+    1. Traverse from left to right
+    2. For each position, find the maximum digit to its right
+    3. If a larger digit exists, swap with its rightmost occurrence
+    4. Return after first beneficial swap (or original if no swap helps)
+    
+    Time Complexity: O(n)
+    Space Complexity: O(n)
+#>
+
+function Get-LargestNumberInOneSwap {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)]
+        [string]$s
+    )
+
+    # Handle edge cases
+    if ($s.Length -le 1) {
+        return $s
+    }
+
+    # Convert string to char array for easy manipulation
+    $chars = $s.ToCharArray()
+    $n = $chars.Length
+
+    # For each position, store the index of the maximum digit to its right
+    # We'll precompute the rightmost maximum from each position
+    
+    # Array to store the index of the rightmost maximum digit from position i to end
+    $rightMaxIndex = New-Object int[] $n
+    
+    # Initialize: the last position's rightmost max is itself
+    $rightMaxIndex[$n - 1] = $n - 1
+    
+    # Fill from right to left
+    for ($i = $n - 2; $i -ge 0; $i--) {
+        # If current digit is greater than the digit at rightMaxIndex[i+1],
+        # then current position becomes the new rightmost max
+        # Note: We use >= to get the RIGHTMOST occurrence of the maximum
+        if ($chars[$i] -gt $chars[$rightMaxIndex[$i + 1]]) {
+            $rightMaxIndex[$i] = $i
+        }
+        else {
+            $rightMaxIndex[$i] = $rightMaxIndex[$i + 1]
+        }
+    }
+
+    # Now traverse from left to find the first position where we can swap
+    for ($i = 0; $i -lt $n; $i++) {
+        # Get the index of the rightmost maximum digit after position i
+        $maxIdx = $rightMaxIndex[$i]
+        
+        # If there's a larger digit to the right, swap and return
+        if ($chars[$maxIdx] -gt $chars[$i]) {
+            # Swap
+            $temp = $chars[$i]
+            $chars[$i] = $chars[$maxIdx]
+            $chars[$maxIdx] = $temp
+            
+            # Return the result
+            return -join $chars
+        }
+    }
+
+    # No beneficial swap found, return original string
+    return $s
+}
+
+# Alternative implementation using a simpler O(n^2) approach
+# (Useful for understanding the logic)
+function Get-LargestNumberInOneSwapSimple {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)]
+        [string]$s
+    )
+
+    # Handle edge cases
+    if ($s.Length -le 1) {
+        return $s
+    }
+
+    $chars = $s.ToCharArray()
+    $n = $chars.Length
+
+    # For each position from left to right
+    for ($i = 0; $i -lt $n; $i++) {
+        $maxDigit = $chars[$i]
+        $maxIdx = -1
+
+        # Find the rightmost digit that is greater than current
+        for ($j = $i + 1; $j -lt $n; $j++) {
+            if ($chars[$j] -ge $maxDigit) {
+                # Only update if strictly greater, or same (to get rightmost)
+                if ($chars[$j] -gt $chars[$i]) {
+                    if ($chars[$j] -ge $maxDigit) {
+                        $maxDigit = $chars[$j]
+                        $maxIdx = $j
+                    }
+                }
+            }
+        }
+
+        # If we found a larger digit, swap and return
+        if ($maxIdx -ne -1) {
+            $temp = $chars[$i]
+            $chars[$i] = $chars[$maxIdx]
+            $chars[$maxIdx] = $temp
+            return -join $chars
+        }
+    }
+
+    return $s
+}
+
+# If running directly (not imported as module), demonstrate the solution
+if ($MyInvocation.InvocationName -ne '.') {
+    Write-Host "=" * 60 -ForegroundColor Cyan
+    Write-Host "Largest Number in One Swap - GfG POTD 2026-03-09" -ForegroundColor Cyan
+    Write-Host "=" * 60 -ForegroundColor Cyan
+    Write-Host ""
+
+    # Test cases
+    $testCases = @(
+        @{ Input = "768"; Expected = "867" },
+        @{ Input = "333"; Expected = "333" },
+        @{ Input = "1993"; Expected = "9913" },
+        @{ Input = "12345"; Expected = "52341" },
+        @{ Input = "98765"; Expected = "98765" },
+        @{ Input = "9"; Expected = "9" },
+        @{ Input = "19"; Expected = "91" },
+        @{ Input = "91"; Expected = "91" },
+        @{ Input = "1234567890"; Expected = "9234567810" }
+    )
+
+    $passCount = 0
+    $failCount = 0
+
+    foreach ($test in $testCases) {
+        $result = Get-LargestNumberInOneSwap -s $test.Input
+        $status = if ($result -eq $test.Expected) { 
+            $passCount++
+            "[PASS]" 
+        } else { 
+            $failCount++
+            "[FAIL]" 
+        }
+        
+        $color = if ($result -eq $test.Expected) { "Green" } else { "Red" }
+        
+        Write-Host "$status Input: `"$($test.Input)`" => Output: `"$result`" (Expected: `"$($test.Expected)`")" -ForegroundColor $color
+    }
+
+    Write-Host ""
+    Write-Host "=" * 60 -ForegroundColor Cyan
+    Write-Host "Results: $passCount passed, $failCount failed" -ForegroundColor $(if ($failCount -eq 0) { "Green" } else { "Yellow" })
+    Write-Host "=" * 60 -ForegroundColor Cyan
+}

--- a/ProblemOfTheDay/2026-03-09_LargestNumberInOneSwap/test_largest_number_one_swap.ps1
+++ b/ProblemOfTheDay/2026-03-09_LargestNumberInOneSwap/test_largest_number_one_swap.ps1
@@ -1,0 +1,161 @@
+<#
+.SYNOPSIS
+    Test script for Largest Number in One Swap solution
+
+.DESCRIPTION
+    Comprehensive tests for the Get-LargestNumberInOneSwap function
+    covering various edge cases and scenarios.
+
+.NOTES
+    Run this script to verify the solution works correctly.
+#>
+
+# Import the solution
+. "$PSScriptRoot\largest_number_one_swap.ps1"
+
+# Test framework
+function Test-Case {
+    param (
+        [string]$Name,
+        [string]$InputString,
+        [string]$Expected
+    )
+
+    $result = Get-LargestNumberInOneSwap -s $InputString
+    $passed = $result -eq $Expected
+
+    [PSCustomObject]@{
+        Name     = $Name
+        Input    = $InputString
+        Expected = $Expected
+        Actual   = $result
+        Passed   = $passed
+    }
+}
+
+Write-Host ""
+Write-Host ("=" * 70) -ForegroundColor Cyan
+Write-Host "  LARGEST NUMBER IN ONE SWAP - TEST SUITE" -ForegroundColor Cyan
+Write-Host "  GeeksforGeeks Problem of the Day - March 9, 2026" -ForegroundColor Cyan
+Write-Host ("=" * 70) -ForegroundColor Cyan
+Write-Host ""
+
+$allTests = @()
+
+# ============================================
+# Basic Test Cases (from problem description)
+# ============================================
+Write-Host "Basic Test Cases:" -ForegroundColor Yellow
+Write-Host ("-" * 40)
+
+$allTests += Test-Case -Name "Example 1: 768" -InputString "768" -Expected "867"
+$allTests += Test-Case -Name "Example 2: All same digits" -InputString "333" -Expected "333"
+
+# ============================================
+# Edge Cases
+# ============================================
+Write-Host ""
+Write-Host "Edge Cases:" -ForegroundColor Yellow
+Write-Host ("-" * 40)
+
+$allTests += Test-Case -Name "Single digit" -InputString "9" -Expected "9"
+$allTests += Test-Case -Name "Two digits - swap needed" -InputString "19" -Expected "91"
+$allTests += Test-Case -Name "Two digits - no swap needed" -InputString "91" -Expected "91"
+$allTests += Test-Case -Name "Two same digits" -InputString "55" -Expected "55"
+
+# ============================================
+# Already Maximum (Descending order)
+# ============================================
+Write-Host ""
+Write-Host "Already Maximum (No swap helps):" -ForegroundColor Yellow
+Write-Host ("-" * 40)
+
+$allTests += Test-Case -Name "Descending 98765" -InputString "98765" -Expected "98765"
+$allTests += Test-Case -Name "Descending 54321" -InputString "54321" -Expected "54321"
+$allTests += Test-Case -Name "Descending 9876543210" -InputString "9876543210" -Expected "9876543210"
+
+# ============================================
+# Ascending order (needs swap)
+# ============================================
+Write-Host ""
+Write-Host "Ascending Order (Swap needed):" -ForegroundColor Yellow
+Write-Host ("-" * 40)
+
+$allTests += Test-Case -Name "Ascending 12345" -InputString "12345" -Expected "52341"
+$allTests += Test-Case -Name "Ascending 123" -InputString "123" -Expected "321"
+$allTests += Test-Case -Name "Ascending with 0" -InputString "1234567890" -Expected "9234567810"
+
+# ============================================
+# Multiple same max digits (rightmost selection)
+# ============================================
+Write-Host ""
+Write-Host "Multiple Same Max Digits (Rightmost selection):" -ForegroundColor Yellow
+Write-Host ("-" * 40)
+
+$allTests += Test-Case -Name "1993 - two 9s" -InputString "1993" -Expected "9913"
+$allTests += Test-Case -Name "2999 - three 9s" -InputString "2999" -Expected "9992"
+$allTests += Test-Case -Name "98368" -InputString "98368" -Expected "98863"
+$allTests += Test-Case -Name "1111191" -InputString "1111191" -Expected "9111111"
+
+# ============================================
+# Special patterns
+# ============================================
+Write-Host ""
+Write-Host "Special Patterns:" -ForegroundColor Yellow
+Write-Host ("-" * 40)
+
+$allTests += Test-Case -Name "Zeros at end" -InputString "1000" -Expected "1000"
+$allTests += Test-Case -Name "Zero at start" -InputString "0123" -Expected "3120"
+$allTests += Test-Case -Name "All zeros" -InputString "0000" -Expected "0000"
+$allTests += Test-Case -Name "987123987" -InputString "987123987" -Expected "997123887"
+
+# ============================================
+# Larger numbers
+# ============================================
+Write-Host ""
+Write-Host "Larger Numbers:" -ForegroundColor Yellow
+Write-Host ("-" * 40)
+
+$allTests += Test-Case -Name "Large ascending" -InputString "123456789012345678901234567890" -Expected "923456789012345678901234567810"
+
+# ============================================
+# Display Results
+# ============================================
+Write-Host ""
+Write-Host ("=" * 70) -ForegroundColor Cyan
+Write-Host "  TEST RESULTS" -ForegroundColor Cyan
+Write-Host ("=" * 70) -ForegroundColor Cyan
+Write-Host ""
+
+$passed = 0
+$failed = 0
+
+foreach ($test in $allTests) {
+    if ($test.Passed) {
+        $passed++
+        Write-Host "[PASS] " -NoNewline -ForegroundColor Green
+        Write-Host "$($test.Name)" -ForegroundColor White
+        Write-Host "       Input: `"$($test.Input)`" => `"$($test.Actual)`"" -ForegroundColor DarkGray
+    }
+    else {
+        $failed++
+        Write-Host "[FAIL] " -NoNewline -ForegroundColor Red
+        Write-Host "$($test.Name)" -ForegroundColor White
+        Write-Host "       Input:    `"$($test.Input)`"" -ForegroundColor DarkGray
+        Write-Host "       Expected: `"$($test.Expected)`"" -ForegroundColor Yellow
+        Write-Host "       Actual:   `"$($test.Actual)`"" -ForegroundColor Red
+    }
+}
+
+Write-Host ""
+Write-Host ("=" * 70) -ForegroundColor Cyan
+$summaryColor = if ($failed -eq 0) { "Green" } else { "Yellow" }
+Write-Host "  SUMMARY: $passed passed, $failed failed out of $($allTests.Count) tests" -ForegroundColor $summaryColor
+Write-Host ("=" * 70) -ForegroundColor Cyan
+Write-Host ""
+
+# Return exit code based on test results
+if ($failed -gt 0) {
+    exit 1
+}
+exit 0


### PR DESCRIPTION
This pull request introduces a complete solution for the "Largest Number in One Swap" problem, including a detailed problem description, an efficient PowerShell implementation, and a comprehensive test suite. The main focus is on finding the lexicographically largest string by performing at most one swap between any two characters in the input string.

**Key changes:**

**Problem Documentation and Explanation**
- Added a detailed `README.md` that describes the problem, provides examples, outlines the algorithmic approach (greedy, rightmost-max swap), and explains time and space complexity.

**Solution Implementation**
- Implemented the `Get-LargestNumberInOneSwap` PowerShell function in `largest_number_one_swap.ps1`, using an O(n) approach with precomputed rightmost maximum indices for efficient swaps. Also included an alternative, simpler O(n²) implementation for educational purposes.
- Added inline demonstration code with multiple sample test cases and colored output for pass/fail status.

**Testing**
- Created a dedicated test script `test_largest_number_one_swap.ps1` that imports the solution and runs a comprehensive set of test cases, covering basic, edge, and complex scenarios. Outputs a summary and sets the exit code based on test results.Add problem for 2026-03-09 with PowerShell implementation that finds the lexicographically largest string achievable with at most one swap. Includes comprehensive tests and detailed algorithm documentation.